### PR TITLE
Fixes error when generating management API

### DIFF
--- a/management/openapi-3.yaml
+++ b/management/openapi-3.yaml
@@ -2013,4 +2013,5 @@ components:
     CreativeTemplateUpdate:
       $ref: './schemas/creative-template.yaml#/schemas/CreativeTemplateUpdate'
   securitySchemes:
-    $ref: './components/security-schemes.yaml#/components/securitySchemes'
+    ApiKeyAuth:
+      $ref: './components/security-schemes.yaml#/components/securitySchemes/ApiKeyAuth'


### PR DESCRIPTION
Hi,

I was getting the following error when trying to generate management client code locally, specifically for rust in this example but I also tried typescript:

        % openapi-generator generate -g rust -i ./management/openapi-3.yaml -o ./build/mgmt-rust/
        Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
         | Error count: 2, Warning count: 2
        Errors: 
	        -attribute components.securitySchemes.SecurityScheme name $ref doesn't adhere to regular expression ^[a-zA-Z0-9\.\-_]+$
	        -attribute components.securitySchemes.$ref is not of type `object`
        Warnings: 
	        -attribute components.securitySchemes.SecurityScheme name $ref doesn't adhere to regular expression ^[a-zA-Z0-9\.\-_]+$
	        -attribute components.securitySchemes.$ref is not of type `object`
        
	        at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:546)
	        at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:573)
	        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:432)
	        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)

OpenAPI Generator version info:

        % openapi-generator --version
        openapi-generator-cli 5.1.0
          commit : e023eaa
          built  : 2021-03-20T09:18:49Z
          source : https://github.com/openapitools/openapi-generator
          docs   : https://openapi-generator.tech/

I checked the generated Rust code and it seemed to be including the API Key header, but I haven't actually tried it out yet.