### PR TITLE
[ch19908] Add access level data to user endpoints

### DIFF
--- a/management/schemas/user.yaml
+++ b/management/schemas/user.yaml
@@ -40,6 +40,6 @@ schemas:
   AccessLevel:
     type: string
     enum:
-      - read-only
-      - editor
-      - admin
+      - read
+      - edit
+      - admn

--- a/management/schemas/user.yaml
+++ b/management/schemas/user.yaml
@@ -12,6 +12,8 @@ schemas:
         type: string
       Name:
         type: string
+      AccessLevel:
+        $ref: '#/schemas/AccessLevel'
       DefaultTimeZone:
         type: string
 
@@ -34,3 +36,10 @@ schemas:
         type: array
         items:
           $ref: '#/schemas/User'
+
+  AccessLevel:
+    type: string
+    enum:
+      - read-only
+      - editor
+      - admin

--- a/management/user.yaml
+++ b/management/user.yaml
@@ -63,6 +63,9 @@ paths:
                 Name:
                   type: string
                   nullable: true
+                AccessLevel:
+                  $ref: './schemas/user.yaml#/schemas/AccessLevel'
+                  nullable: true
                 DefaultTimeZone:
                   type: string
                   nullable: true
@@ -104,6 +107,9 @@ paths:
                   type: string
                 Name:
                   type: string
+                AccessLevel:
+                  $ref: './schemas/user.yaml#/schemas/AccessLevel'
+                  nullable: true
                 DefaultTimeZone:
                   type: string
                   nullable: true


### PR DESCRIPTION
As part of Core UI's work adding basic roles and permissions to the Management app, we're adding a notion of "access levels" controlled via a new table in SQL Server, `AccessLevel`, that's linked to users on a per-network basis. To work with this new kind of user data, we need to augment the User endpoints with access level data.

This PR adds `AccessLevel` as part of the readable User data and adds optional `AccessLevel` parameters to the Create and Update endpoints. It also enumerates the valid values in a schema.

**These changes are not yet in prod.** (The PR in api-proxy is https://github.com/adzerk/api-proxy/pull/303 .)