### PR TITLE
[ch21091] Add Decimal versions for flight caps

### DIFF
--- a/management/flight.yaml
+++ b/management/flight.yaml
@@ -186,9 +186,17 @@ paths:
                   type: integer
                   format: int32
                   nullable: true
+                DailyCapAmountDecimal:
+                  type: number
+                  format: float
+                  nullable: true
                 LifetimeCapAmount:
                   type: integer
                   format: int32
+                  nullable: true
+                LifetimeCapAmountDecimal:
+                  type: number
+                  format: float
                   nullable: true
                 Keywords:
                   type: string

--- a/management/schemas/flight.yaml
+++ b/management/schemas/flight.yaml
@@ -61,9 +61,17 @@ schemas:
         type: integer
         format: int32
         nullable: true
+      DailyCapAmountDecimal:
+        type: number
+        format: float
+        nullable: true
       LifetimeCapAmount:
         type: integer
         format: int32
+        nullable: true
+      LifetimeCapAmountDecimal:
+        type: number
+        format: float
         nullable: true
       Keywords:
         type: string


### PR DESCRIPTION
This adds specifications for the DailyCapAmountDecimal and LifetimeCapAmountDecimal that we are adding to the Flights API (coming soon for the Campaign and Advertiser endpoints).

I was able to successfully regenerate the typescript files (with the PR in #14) and saw the new items in the models. I'm not sure how this change gets propagated to the docs, so would appreciate any pointers about other things I should test or change.

Thanks!