### PR TITLE
ch22061/Add CanAccessStudio to User Management Api.

### DIFF
--- a/management/schemas/user.yaml
+++ b/management/schemas/user.yaml
@@ -16,6 +16,8 @@ schemas:
         $ref: '#/schemas/AccessLevel'
       DefaultTimeZone:
         type: string
+      CanAccessStudio:
+        type: boolean
 
   UserList:
     type: object

--- a/management/user.yaml
+++ b/management/user.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
-  title: Adzerk Management API - Scheduled Reporting
-  description: Scheduled Reporting related Adzerk Management API
+  title: Adzerk Management API - User Management
+  description: Manage access to Kevel, create new Kevel users, or update the names or emails of Kevel users in your account
   version: '1.0'
 servers:
   - url: 'https://api.adzerk.net'
@@ -69,6 +69,8 @@ paths:
                 DefaultTimeZone:
                   type: string
                   nullable: true
+                CanAccessStudio:
+                  type: boolean
       responses:
         200:
           description: The user
@@ -113,6 +115,8 @@ paths:
                 DefaultTimeZone:
                   type: string
                   nullable: true
+                CanAccessStudio:
+                  type: boolean
       responses:
         200:
           description: Updated User


### PR DESCRIPTION
See https://dev.kevel.co/reference/log-in-endpoints
and search for:
`CanAccessStudio`

Updated open api spec on user.yaml to reflect these changes. The API changes are now in production.
Feel free to review+merge (or leave review feedback, and I'll address).