### PR TITLE
Add Object to the enum of creative template field types

### DIFF
--- a/management/creative-template.yaml
+++ b/management/creative-template.yaml
@@ -86,7 +86,7 @@ paths:
                         pattern: '^ct[a-zA-Z0-9]+'
                       Type:
                         type: string
-                        enum: [String, File, ExternalFile, Array]
+                        enum: [String, File, ExternalFile, Array, Object]
                       Required:
                         type: boolean
                         default: false


### PR DESCRIPTION
Shortcut story: https://app.shortcut.com/adzerk/story/25018/add-object-creative-template-field-type

I think the only change to the Management API here is that we are adding "Object" as an acceptable value for the type of a creative template field. There is also validation that if you choose Object as the type of a field and you include a Default value for that field, then the value you supply must be an object (and not, say, an array, a string, or a number), but as far as I can tell from looking at the API specification in this repo, nothing needs to be adjusted with respect to that validation.

The Management API changes haven't gone into production yet. The PR is here: https://github.com/adzerk/api-proxy/pull/350