### PR TITLE
Update Login API spec (New "Ad Manager" access level; Password no longer required)

### DIFF
--- a/management/schemas/user.yaml
+++ b/management/schemas/user.yaml
@@ -43,5 +43,6 @@ schemas:
     type: string
     enum:
       - read
+      - amgr
       - edit
       - admn

--- a/management/user.yaml
+++ b/management/user.yaml
@@ -54,7 +54,6 @@ paths:
               type: object
               required:
                 - Email
-                - Password
               properties:
                 Email:
                   type: string


### PR DESCRIPTION
These changes are not yet in production. The api-proxy PR is here: https://github.com/adzerk/api-proxy/pull/417