### PR TITLE
Set Publish to Public

### DIFF
--- a/.github/workflows/publish-decision-spec-packages.yml
+++ b/.github/workflows/publish-decision-spec-packages.yml
@@ -72,14 +72,14 @@ jobs:
         working-directory: ${{ env.WORKINGDIRECTORY_DECISION }}
         run: |
           echo "Publishing tag ${GITHUB_REF_NAME} to ${NPM_REGISTRY}."
-          npm publish
+          npm publish --access=public
 
       - id: c3c47fb3-2620-4dd1-898b-e867303278ea
         name: Publish Package to GitHub Packages
         env:
           NPM_REGISTRY: npm.pkg.github.com
-          NPM_SECRET: ${{ secrets.GITHUB_TOKEN }}
+          NPM_SECRET: ${{ secrets.GITHUB_T }}
         working-directory: ${{ env.WORKINGDIRECTORY_DECISION }}
         run: |
           echo "Publishing tag ${GITHUB_REF_NAME} to ${NPM_REGISTRY}."
-          npm publish
+          npm publish --access=public

--- a/.github/workflows/publish-decision-spec-packages.yml
+++ b/.github/workflows/publish-decision-spec-packages.yml
@@ -78,7 +78,7 @@ jobs:
         name: Publish Package to GitHub Packages
         env:
           NPM_REGISTRY: npm.pkg.github.com
-          NPM_SECRET: ${{ secrets.GITHUB_T }}
+          NPM_SECRET: ${{ secrets.GITHUB_TOKEN }}
         working-directory: ${{ env.WORKINGDIRECTORY_DECISION }}
         run: |
           echo "Publishing tag ${GITHUB_REF_NAME} to ${NPM_REGISTRY}."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [sc-48140] Added `npm publish` option `--access=public` to permit publish to public npm registry and not receive `You must sign up for private packages` due to scoped packages [being `restricted` by default](https://docs.npmjs.com/cli/v8/commands/npm-publish#access). By [@honeycomb-cheesecake](https://github.com/honeycomb-cheesecake).
+
+## [1.0.7] - [sc-48140] 2023-08-15
+
+### Fixed
+
 - [sc-48140] Typescript stage in publish workflow to target the correct version of Javascript. By [@honeycomb-cheesecake](https://github.com/honeycomb-cheesecake).
 
 ### Changed


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## [Unreleased]

### Fixed

- [sc-48140] Added `npm publish` option `--access=public` to permit publish to public npm registry and not receive `You must sign up for private packages` due to scoped packages [being `restricted` by default](https://docs.npmjs.com/cli/v8/commands/npm-publish#access). By [@honeycomb-cheesecake](https://github.com/honeycomb-cheesecake).