### PR TITLE
Targeting `ES5` for Compatibility

### DIFF
--- a/.github/workflows/publish-decision-spec-packages.yml
+++ b/.github/workflows/publish-decision-spec-packages.yml
@@ -51,8 +51,8 @@ jobs:
         name: Compile Package
         working-directory: ${{ env.WORKINGDIRECTORY_DECISION }}
         run: |
-          tsc --outDir dist --declaration --target es5 --moduleResolution nodenext --showConfig *.ts
-          tsc --outDir dist --declaration --target es5 --moduleResolution nodenext *.ts
+          tsc --outDir dist --declaration --target es5 --moduleResolution nodenext --lib es6,dom --showConfig *.ts
+          tsc --outDir dist --declaration --target es5 --moduleResolution nodenext --lib es6,dom *.ts
 
       - id: edd89b5d-54fa-4951-8206-54b1cef91968
         name: Configure Project-Level .npmrc File

--- a/.github/workflows/publish-decision-spec-packages.yml
+++ b/.github/workflows/publish-decision-spec-packages.yml
@@ -51,8 +51,8 @@ jobs:
         name: Compile Package
         working-directory: ${{ env.WORKINGDIRECTORY_DECISION }}
         run: |
-          tsc --outDir dist --declaration --target es6 --moduleResolution nodenext --showConfig *.ts
-          tsc --outDir dist --declaration --target es6 --moduleResolution nodenext *.ts
+          tsc --outDir dist --declaration --target es5 --moduleResolution nodenext --showConfig *.ts
+          tsc --outDir dist --declaration --target es5 --moduleResolution nodenext *.ts
 
       - id: edd89b5d-54fa-4951-8206-54b1cef91968
         name: Configure Project-Level .npmrc File

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [sc-48140] Targeting Javascript `ES5` instead of `ES6` for compatability. By [@honeycomb-cheesecake](https://github.com/honeycomb-cheesecake).
+- [sc-48140] Fixed clean script. By [@honeycomb-cheesecake](https://github.com/honeycomb-cheesecake).
+
+## [1.0.9] - [sc-48140] 2023-08-15
+
+### Nothing
+
+- Problem with deploy due to GITHUB_REF_NAME, so republished. By [@honeycomb-cheesecake](https://github.com/honeycomb-cheesecake).
+
+## [1.0.8] - [sc-48140] 2023-08-15
+
+### Fixed
+
 - [sc-48140] Added `npm publish` option `--access=public` to permit publish to public npm registry and not receive `You must sign up for private packages` due to scoped packages [being `restricted` by default](https://docs.npmjs.com/cli/v8/commands/npm-publish#access). By [@honeycomb-cheesecake](https://github.com/honeycomb-cheesecake).
 
 ## [1.0.7] - [sc-48140] 2023-08-15

--- a/decision/codegen-config/typescript-fetch.json
+++ b/decision/codegen-config/typescript-fetch.json
@@ -1,6 +1,5 @@
 {
   "enablePostProcessFile": true,
-  "supportsES6": true,
   "typescriptThreePlus": true,
   "useSingleRequestParameter": false
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-management-csharp": "npx @openapitools/openapi-generator-cli generate --input-spec ./management/openapi-3.yaml --generator-name csharp --output ./.build/cs/management --config ./management/codegen-config/csharp-netcore.json --skip-validate-spec",
     "build-management-ruby": "npx @openapitools/openapi-generator-cli generate --input-spec ./management/openapi-3.yaml --generator-name ruby --output ./.build/rb/management --config ./management/codegen-config/ruby.json --skip-validate-spec",
     "build-management-typescript": "npx @openapitools/openapi-generator-cli generate --input-spec ./management/openapi-3.yaml --generator-name typescript-fetch --output ./.build/ts/management --config ./management/codegen-config/typescript-fetch.json --skip-validate-spec",
-    "clean": "rm -rf build"
+    "clean": "rm -rf .build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## [Unreleased]

### Fixed

- [sc-48140] Targeting Javascript `ES5` instead of `ES6` for compatability. By [@honeycomb-cheesecake](https://github.com/honeycomb-cheesecake).
- [sc-48140] Fixed clean script. By [@honeycomb-cheesecake](https://github.com/honeycomb-cheesecake).