### PR TITLE
Temp fix to get latest api-spec working again

### DIFF
--- a/management/flight.yaml
+++ b/management/flight.yaml
@@ -384,28 +384,12 @@ paths:
                   required:
                     - MatchType
                     - LookbackWindow
-                  properties:
-                    MatchType:
-                      type: string
-                      enum: ["SameProduct", "SameCategoryBrand", "SameBrand"]
-                    LookbackWindow:
-                      type: integer
-                      format: int32
-                      enum: [1, 7, 14, 30]
                 AttributionView:
                   type: object
                   nullable: true
                   required:
                     - MatchType
                     - LookbackWindow
-                  properties:
-                    MatchType:
-                      type: string
-                      enum: ["SameProduct", "SameCategoryBrand", "SameBrand"]
-                    LookbackWindow:
-                      type: integer
-                      format: int32
-                      enum: [1, 7, 14, 30]
                 TargetROAS:
                   type: number
                   format: float
@@ -679,28 +663,12 @@ paths:
                   required:
                     - MatchType
                     - LookbackWindow
-                  properties:
-                    MatchType:
-                      type: string
-                      enum: ["SameProduct", "SameCategoryBrand", "SameBrand"]
-                    LookbackWindow:
-                      type: integer
-                      format: int32
-                      enum: [1, 7, 14, 30]
                 AttributionView:
                   type: object
                   nullable: true
                   required:
                     - MatchType
                     - LookbackWindow
-                  properties:
-                    MatchType:
-                      type: string
-                      enum: ["SameProduct", "SameCategoryBrand", "SameBrand"]
-                    LookbackWindow:
-                      type: integer
-                      format: int32
-                      enum: [1, 7, 14, 30]
                 TargetROAS:
                   type: number
                   format: float

--- a/management/schemas/flight.yaml
+++ b/management/schemas/flight.yaml
@@ -241,24 +241,12 @@ schemas:
         required:
           - MatchType
           - LookbackWindow
-        properties:
-          MatchType:
-            type: string
-          LookbackWindow:
-            type: integer
-            format: int32
       AttributionView:
         type: object
         nullable: true
         required:
           - MatchType
           - LookbackWindow
-        properties:
-          MatchType:
-            type: string
-          LookbackWindow:
-            type: integer
-            format: int32
       TargetROAS:
         type: number
         format: float


### PR DESCRIPTION
I've tested this by pushing it to S3 and pulling it down via the api-client to successfully make a flight.

I think there's a problem with our validation code not handling nested objects (as this if the first nested object that we've documented in our spec AFAICT).

This is a suboptimal fix because it doesn't include the specification for the nested fields, but it will at least get things working again. 