### PR TITLE
sc-48835 fix build errors and warnings

### DIFF
--- a/management/openapi-3.yaml
+++ b/management/openapi-3.yaml
@@ -2020,4 +2020,7 @@ components:
     CreativeTemplateUpdate:
       $ref: './schemas/creative-template.yaml#/schemas/CreativeTemplateUpdate'
   securitySchemes:
-    $ref: './components/security-schemes.yaml#/components/securitySchemes'
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Adzerk-ApiKey


### PR DESCRIPTION
PR fixes both sc-48835 and sc-48834. Fixes the errors and warnings when building the Management openapi spec. 

Before: 
![Screenshot 2023-08-30 at 2 38 48 PM](https://github.com/adzerk/adzerk-api-specification/assets/19581165/0330056d-bdee-4488-aac4-46e5ffd28005)

After:
![Screenshot 2023-08-30 at 2 55 06 PM](https://github.com/adzerk/adzerk-api-specification/assets/19581165/8759b4d6-7075-40f1-ae1e-e8c4afd5067d)
