### PR TITLE
[sc-51904] Flight RateType can no longer be NULL

### DIFF
--- a/management/flight.yaml
+++ b/management/flight.yaml
@@ -199,7 +199,6 @@ paths:
                   type: integer
                   format: int32
                   enum: [1, 2, 3, 4, 5, 6]
-                  nullable: true
                 Price:
                   type: number
                   format: float

--- a/management/schemas/flight.yaml
+++ b/management/schemas/flight.yaml
@@ -38,7 +38,6 @@ schemas:
         type: integer
         format: int32
         enum: [1, 2, 3, 4, 5, 6]
-        nullable: true
       Price:
         type: number
         format: float


### PR DESCRIPTION
Validation rule has been updated for Flight RateType to disallow `null`.

Related:
- https://github.com/adzerk/api-proxy/pull/741