### PR TITLE
[sc-66733] Publish to version dir only when release is published

### DIFF
--- a/.github/workflows/publish-management-spec.yml
+++ b/.github/workflows/publish-management-spec.yml
@@ -1,8 +1,7 @@
 name: Publish Management API OpenAPI Specification
 on:
-  push:
-    branches: [master]
-    tags: [v*]
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -27,10 +26,14 @@ jobs:
           tags: '[{"Key": "BillingGroup", "Value": "Developer Experience"}]'
           no-fail-on-empty-changeset: 1
 
-      - name: Publish latest specifications to S3
-        run: |
-          cd management
-          aws s3 cp . s3://developer-exp-management-api-specification --recursive --exclude "*" --include "*.yaml" --acl "public-read"
+      # [sc-66733] Do not publish to the root until there is an enduring solution to the 
+      # caching issue whereby the CDN can serve a mixture of new and old schema files 
+      # for a period after a release being published.
+      #
+      # - name: Publish latest specifications to S3
+      #   run: |
+      #     cd management
+      #     aws s3 cp . s3://developer-exp-management-api-specification --recursive --exclude "*" --include "*.yaml" --acl "public-read"
 
       - name: Publish tagged version to S3
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
The decision to only publish new versions of the API spec was made after the postmortem: [2024-12-05 [SEV-3] Management Open API Spec served old schema files from cache](https://kevel.getoutline.com/doc/2024-12-05-sev-3-management-open-api-spec-served-old-schema-files-from-cache-2augWAHNb0)

> Change the release of the spec so that it management only releases on tagged version and not changes to the master branch. A release of a spec should not update the root schemas - it’ll always be pinned to v1.0.14