### PR TITLE
Add advertiserId and isArchived query params to list campaigns

### DIFF
--- a/management/campaign.yaml
+++ b/management/campaign.yaml
@@ -74,6 +74,21 @@ paths:
             type: integer
             format: int32
             nullable: true
+        - name: advertiserId
+          in: query
+          description: Returns only campaigns that belong to that advertiser Id
+          required: false
+          schema:
+            type: integer
+            format: int32
+            nullable: true
+        - name: isArchived
+          in: query
+          description: Returns only archived flights if true
+          required: false
+          schema:
+            type: boolean
+            nullable: true
       responses:
         200:
           description: Paged list of Campaigns

--- a/management/openapi-3.yaml
+++ b/management/openapi-3.yaml
@@ -235,6 +235,21 @@ paths:
             type: integer
             format: int32
             nullable: true
+        - name: advertiserId
+          in: query
+          description: Returns only campaigns that belong to that advertiser Id
+          required: false
+          schema:
+            type: integer
+            format: int32
+            nullable: true
+        - name: isArchived
+          in: query
+          description: Returns only archived flights if true
+          required: false
+          schema:
+            type: boolean
+            nullable: true
       responses:
         200:
           description: Paged list of Campaigns


### PR DESCRIPTION
Added additional query params accepted by `GET /v1/campaign` endpoint.

Addresses https://github.com/adzerk/adzerk-api-specification/issues/34

Tested using JS SDK:

```js
let Adzerk = require("@adzerk/management-sdk");

async function run() {
  let specificationList = Adzerk.buildFullSpecificationList({
    basePath: "../adzerk-api-specification/management",
  });
  let specifications = await Adzerk.fetchSpecifications(specificationList);
  let client = await Adzerk.buildClient({
    apiKey: "REDACTED",
    specifications,
  });

  const result = await client.run("campaign", "list", {
    advertiserId: 2714470,
  });

  console.log(result);
}
run();

```