### PR TITLE
Fix Advertiser/CatalogAccess/ProductQuery array type

### DIFF
--- a/management/schemas/advertiser.yaml
+++ b/management/schemas/advertiser.yaml
@@ -72,7 +72,8 @@ schemas:
               type: array
               items:
                 type: array
-                items: string
+                items:
+                  type: string
               nullable: true
 
   AdvertiserUpdate:
@@ -150,7 +151,8 @@ schemas:
               type: array
               items:
                 type: array
-                items: string
+                items:
+                  type: string
               nullable: true
 
   Advertiser:


### PR DESCRIPTION
Fix for the array type spec for the new Advertiser/CatalogAccess/ProductQuery array type in v1.0.20 https://github.com/adzerk/adzerk-api-specification/compare/v1.0.19...v1.0.20#diff-3afd1578b759bd322e4e7db5b2fefcba340adda0c1d7e5b45df110ac424ee5a5R75