### PR TITLE
Adding schema ref to `decisions` property under `DecisionResponse`

### DIFF
--- a/decision/openapi-3.yaml
+++ b/decision/openapi-3.yaml
@@ -632,6 +632,8 @@ components:
           $ref: '#/components/schemas/User'
         decisions:
           type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Decision'
         explain:
           type: object
     ConsentRequest:


### PR DESCRIPTION
The `Decision` schema was defined but not referenced in `DecisionResponse`. This PR adds the missing reference.