### PR TITLE
Decsion SDK: Add support for searchTerm in skipFilters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.27] - 2026-06-12
+
+### Fixed
+
+- [SUPPORT-1475] Added missing `searchTerm` property to the `SkipFilters` schema in the Decision API spec, so generated clients no longer strip `skipFilters.searchTerm` from decision requests. By [@vkurup](https://github.com/vkurup).
+
 ## [1.0.13] - 2023-11-13
 
 ### Added

--- a/decision/openapi-3.yaml
+++ b/decision/openapi-3.yaml
@@ -687,6 +687,9 @@ components:
         placementLimit:
           type: boolean
           description: Placement limit filter, where no advertiser placement limit if true.
+        searchTerm:
+          type: boolean
+          description: Search term filter, which skips search term targeting if true.
         siteZone:
           type: boolean
           description: Site/zone limit filter, which skips site/zone targeting if true.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adzerk/api-specification",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adzerk/api-specification",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "^2.15.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adzerk/api-specification",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "license": "Apache-2.0",
   "description": "Kevel API Specification",
   "main": "index.js",


### PR DESCRIPTION
The Decision API accepts skipFilters.searchTerm, but it was missing from the SkipFilters schema, so generated clients (e.g. @adzerk/api-decision-js) silently strip it before sending. Adds the property, bumps to 1.0.27.
