### PR TITLE
[SUPPORT-1475] Fix publishing failure by updating nodejs to v24

### DIFF
--- a/.github/workflows/publish-decision-spec-packages.yml
+++ b/.github/workflows/publish-decision-spec-packages.yml
@@ -14,17 +14,17 @@ jobs:
     steps:
       - id: a9c19221-2149-41f2-91d7-e8411bf3ecc5
         name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: ba48f425-ccc1-4288-8ff6-4a1812e83224
         name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
 
       - id: f7414109-3255-4132-a3c9-6e38a68e54fe
         name: Setup Java (Needed by Generator)
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/publish-management-spec.yml
+++ b/.github/workflows/publish-management-spec.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
The [publish failed](https://github.com/adzerk/adzerk-api-specification/actions/runs/27571532177) because NodeJS was out of date. This updates Node from 18->24